### PR TITLE
Fix for picking up delay param in release command

### DIFF
--- a/beanstalkd/core/cmd_data.go
+++ b/beanstalkd/core/cmd_data.go
@@ -295,7 +295,7 @@ func NewReleaseArg(data *CmdData) (*releaseArg, error) {
 		return nil, ErrBadFormat
 	}
 
-	delay, err := strconv.ParseInt(tm["pri"], 10, 64)
+	delay, err := strconv.ParseInt(tm["delay"], 10, 64)
 	if err != nil {
 		log.Errorf("NewReleaseArg: ParseInt(delay) err=%v", err)
 		return nil, ErrBadFormat

--- a/beanstalkd/core/cmd_data_test.go
+++ b/beanstalkd/core/cmd_data_test.go
@@ -232,3 +232,32 @@ func TestKickArg(t *testing.T) {
 		assert.Equalf(t, e.outArg, pa, e.msg)
 	}
 }
+
+func TestReleaseArg(t *testing.T)  {
+	// bury <id> <pri>
+	var entries = []struct {
+		inArg  string
+		outArg *releaseArg
+		err    error
+		msg    string
+	}{
+		{"12328 1 10", &releaseArg{id: 12328, pri: 1, delay: 10}, nil,
+			"expect valid arg"},
+		{"10 100 ", nil, ErrBadFormat,
+			"must have exact arg count"},
+		{"32898abc", nil, ErrBadFormat,
+			"args must have numeric args"},
+	}
+
+	for _, e := range entries {
+		d := &CmdData{
+			CmdType:  Unknown,
+			Args:     e.inArg,
+			Data:     nil,
+			NeedData: false,
+		}
+		pa, err := NewReleaseArg(d)
+		assert.Equalf(t, e.err, err, e.msg)
+		assert.Equalf(t, e.outArg, pa, e.msg)
+	}
+}


### PR DESCRIPTION
Summary:

Bugfix for issue https://github.com/1xyz/coolbeans/issues/20

The delay parameter was not being picked (the pri param was picked up instead)

Add unit-test coverage

Resolve #20 