### PR TITLE
Summary: Bug fix. for ErrJobSizeTooBig

### DIFF
--- a/beanstalkd/core/cmd_data_test.go
+++ b/beanstalkd/core/cmd_data_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -22,13 +23,21 @@ func TestParseCommandLine(t *testing.T) {
 			ErrCmdNotFound,
 			"expect ErrCmdNotFound to be returned"},
 		{"put",
-			&CmdData{Put, "", []byte{}, true},
 			nil,
-			"expect cmdline to be parse even if there are no args"},
+			ErrBadFormat,
+			"expect cmdline to return ErrBadFormat for Put if there are no args"},
+		{"stats-tube",
+			&CmdData{StatsTube, "", nil, false},
+			nil,
+			"expect cmdline to return nil for other commands if there are no args"},
 		{"  ",
 			nil,
 			ErrCmdTokensMissing,
 			"expect ErrCmdTokensMissing to be returned"},
+		{fmt.Sprintf("put 0 100 30 %d", MaxJobDataSizeBytes+1),
+			nil,
+			ErrJobSizeTooBig,
+			"expect valid put parsing"},
 	}
 
 	for _, e := range entries {

--- a/beanstalkd/core/core.go
+++ b/beanstalkd/core/core.go
@@ -22,7 +22,7 @@ const (
 	MaxCmdSizeBytes = 226
 
 	// Max. Job Data size in bytes (inclusive of 2 byte delimiter)
-	MaxJobDataSizeBytes = (16 * 1024) + 2
+	MaxJobDataSizeBytes = (128 * 1024) + 2
 
 	// The size of a read buffer
 	readBufferSizeBytes = 4 * 1024
@@ -60,6 +60,12 @@ const (
 
 	// Error message to indicate if the entity (job etc) cannot be found
 	MsgNotFound = "NOT_FOUND"
+
+	// Error message to indicate that the job is too big
+	MsgJobTooBig = "JOB_TOO_BIG"
+
+	// Error message to indicate that CRLF is needed
+	MsgExpectCRLF = "EXPECTED_CRLF"
 )
 
 var (
@@ -76,6 +82,9 @@ var (
 	// characters occur where an integer is expected, if the wrong number of
 	// arguments are present, or if the command line is mal-formed in any other
 	ErrBadFormat = errors.New("bad format command")
+
+	// ErrJobSizeTooBig he client has requested to put a job with a body larger that the configured limit
+	ErrJobSizeTooBig = errors.New("job size too big")
 
 	// ErrCmdTokensMissing - when the provided command has no tokens
 	ErrCmdTokensMissing = errors.New("bad command, cannot find atleast one token")


### PR DESCRIPTION
Problem: when a job > the prescribed job size limit is posted a ErrBadFormat is returned, it is expected to return ErrJobSizeTooBig

Fix: Added special case handling when the put job's size is higher than the posted value

Resolves #25 