### PR TITLE
Update release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-![Build](https://github.com/1xyz/coolbeans/workflows/Build/badge.svg)
-![Release](https://github.com/1xyz/coolbeans/workflows/Release/badge.svg)
-![Docker](https://img.shields.io/docker/pulls/1xyz/coolbeans)
+[![Build](https://github.com/1xyz/coolbeans/workflows/Build/badge.svg)](https://github.com/1xyz/coolbeans/actions?query=workflow%3ABuild)
+[![Release](https://github.com/1xyz/coolbeans/workflows/Release/badge.svg)](https://github.com/1xyz/coolbeans/actions?query=workflow%3ARelease)
+[![Docker](https://img.shields.io/docker/pulls/1xyz/coolbeans)](https://hub.docker.com/r/1xyz/coolbeans/tags)
+
+
 
 - [Coolbeans](#coolbeans)
     - [Motivation](#motivation)
@@ -42,8 +44,9 @@ Key features
 Releases
 --------
 
-- Static binary can be downloaded from the [release pages](https://github.com/1xyz/coolbeans/releases)
-- Docker image  can be pulled from [here](https://hub.docker.com/r/1xyz/coolbeans)
+- Static binary can be downloaded from the [release pages](https://github.com/1xyz/coolbeans/releases).
+- Docker release images can be pulled from [here](https://hub.docker.com/r/1xyz/coolbeans).
+- Docker development images can be pulled from [here](https://hub.docker.com/r/1xyz/coolbeans-developer/tags).
 
 
 Getting Started 

--- a/generate_changelog.sh
+++ b/generate_changelog.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+current_tag=$(git describe --tags)
+previous_tag=$(git tag --sort=-creatordate   | head -n 2 | tail -n 1)
+
+tag_date=$(git log -1 --pretty=format:'%ad' --date=short ${current_tag})
+printf "## ${current_tag} (${tag_date})\n\n"
+git log ${current_tag}...${previous_tag} --pretty=format:'*  %s [View](https://github.com/1xyz/coolbeans/commit/%H)' --reverse | grep -v Merge


### PR DESCRIPTION
Updates release workflow and documentation

After a few experiments with github actions
- Added badges for README for docker pulls, build and release
- Updated the release workflow to generate linux and darwin zip archives
- Had some wrestling to get changelog comments into releases, a little bit of challenge there

Note: most of the changes were in master

Fixes #32 
