### PR TITLE
Allow tube names based on protocol

### DIFF
--- a/beanstalkd/core/cmd_data.go
+++ b/beanstalkd/core/cmd_data.go
@@ -96,7 +96,7 @@ var (
 	putRe = regexp.MustCompile(`^(?P<pri>\d+) (?P<delay>\d+) (?P<ttr>\d+) (?P<bytes>\d+)$`)
 
 	// tube arg regex -- watch <tube> | ignore <tube> | use <tube>
-	tubeArgRe = regexp.MustCompile(`(?P<tube>^\w{1,200}$)`)
+	tubeArgRe = regexp.MustCompile(`(?P<tube>^[a-zA-Z0-9+\/;.$_()][a-zA-Z0-9\-+\/;.$_()]{0,199}$)`)
 
 	// id arg regex --
 	// delete <id>

--- a/beanstalkd/core/cmd_data_test.go
+++ b/beanstalkd/core/cmd_data_test.go
@@ -93,6 +93,12 @@ func TestTubeArg(t *testing.T) {
 			"tube cannot have spaces"},
 		{strN('a', 201), nil, ErrBadFormat,
 			"tube name cannot exceed 200 bytes"},
+		{"-abc", nil, ErrBadFormat,
+			"tube cannot start with '-'"},
+		{"asd-AAZ213;$_/.(+)", &tubeArg{tubeName: "asd-AAZ213;$_/.(+)"}, nil,
+			"expect valid tubename"},
+		{"x", &tubeArg{tubeName: "x"}, nil,
+			"expect valid tubename"},
 	}
 
 	for _, e := range entries {


### PR DESCRIPTION
Currently tube names can only be alphanumeric + underscore, but the
protocol allows additional characters such as hyphens.

This updates the tube name validation to match the protocol.